### PR TITLE
Main task unload errs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
+/experimental
 Cargo.lock
-/docs
 notes.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ name = "hexchat_api"
 libc = "0.2.84"
 backtrace = "0.3"
 send_wrapper = "0.6.0"
+
+[features]
+default = ["threadsafe"]
+threadsafe = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,8 +15,10 @@ use std::error;
 use std::fmt;
 use std::ffi::CString;
 use std::rc::Rc;
+#[cfg(feature = "threadsafe")]
 use std::thread;
 
+#[cfg(feature = "threadsafe")]
 use crate::MAIN_THREAD_ID;
 use crate::hexchat::{Hexchat, hexchat_context, HexchatError};
 use crate::hexchat_entry_points::PHEXCHAT;
@@ -57,6 +59,7 @@ impl Context {
     /// returned as a `Some<Context>` if the context is found, or `None` if
     /// not.
     pub fn find(network: &str, channel: &str) -> Option<Self> {
+        #[cfg(feature = "threadsafe")]
         assert!(thread::current().id() == unsafe { MAIN_THREAD_ID.unwrap() },
                 "Context::find() must be called from the Hexchat main thread.");
         let csnetwork = str2cstring(network);
@@ -87,6 +90,7 @@ impl Context {
     /// `Result<Context, ()>` is returned with either the context, or an
     /// error result if it coulnd't be obtained.
     pub fn get() -> Option<Self> {
+        #[cfg(feature = "threadsafe")]
         assert!(thread::current().id() == unsafe { MAIN_THREAD_ID.unwrap() },
                 "Context::get() must be called from the Hexchat main thread.");
         unsafe {

--- a/src/hexchat.rs
+++ b/src/hexchat.rs
@@ -18,12 +18,14 @@ use crate::callback_data::{CallbackData, TimerCallbackOnce};
 use crate::context::Context;
 use crate::context::ContextError;
 use crate::hexchat_callbacks::*;
+#[cfg(feature = "threadsafe")]
 use crate::hexchat_entry_points::PHEXCHAT;
 use crate::hook::Hook;
 use crate::list_iterator::ListIterator;
 use crate::plugin::Plugin;
 use crate::user_data::*;
 use crate::utils::*;
+#[cfg(feature = "threadsafe")]
 use crate::threadsafe_hexchat::*;
 
 /// Value used in example from the Hexchat Plugin Interface doc web page.
@@ -76,6 +78,7 @@ impl Hexchat {
     /// Returns a thread-safe wrapper for `Hexchat` that exposes thread-safe
     /// methods wrapping several of `Hexchat`s methods.
     ///
+    #[cfg(feature = "threadsafe")]
     pub fn threadsafe(&self) -> ThreadSafeHexchat {
         ThreadSafeHexchat::new(unsafe { &*PHEXCHAT })
     }

--- a/src/hexchat_entry_points.rs
+++ b/src/hexchat_entry_points.rs
@@ -24,6 +24,7 @@ use std::ptr::NonNull;
 use crate::hexchat::Hexchat;
 use crate::hook::*;
 use crate::utils::*;
+#[cfg(feature = "threadsafe")]
 use crate::thread_facilities::*;
 
 /// The signature for the init function that plugin authors need to register
@@ -218,6 +219,7 @@ pub fn lib_hexchat_plugin_init(hexchat   : &'static Hexchat,
     // Invoke client lib's init function.
     catch_unwind(|| { 
         Hook::init();
+        #[cfg(feature = "threadsafe")]
         main_thread_init();
         init_cb(hexchat) 
     }).unwrap_or(0)
@@ -239,6 +241,7 @@ pub fn lib_hexchat_plugin_deinit(hexchat  : &'static Hexchat,
         // Call user's deinit().
         let retval = callback(hexchat);
         
+        #[cfg(feature = "threadsafe")]
         main_thread_deinit();
         
         // Cause the callback_data objects to drop and clean up.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,13 @@ pub use hexchat_entry_points::*;
 pub use list_item::*;
 pub use list_iterator::*;
 pub use plugin::*;
+#[cfg(feature = "threadsafe")]
 pub use thread_facilities::*;
+#[cfg(feature = "threadsafe")]
 pub use threadsafe_context::*;
+#[cfg(feature = "threadsafe")]
 pub use threadsafe_hexchat::*;
+#[cfg(feature = "threadsafe")]
 pub use threadsafe_list_iterator::*;
 pub use user_data::*;
 #[allow(unused_imports)]

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -10,10 +10,12 @@
 use libc::c_void;
 use libc::time_t;
 use std::cell::RefCell;
+#[cfg(feature = "threadsafe")]
 use std::thread;
 use std::{fmt, error};
 use std::rc::Rc;
 
+#[cfg(feature = "threadsafe")]
 use crate::MAIN_THREAD_ID;
 use crate::context::*;
 use crate::hexchat::Hexchat;
@@ -47,6 +49,7 @@ impl ListIterator {
     ///   `Ok` holds a `ListIterator` instance.
     ///
     pub fn new(list_name: &str) -> Option<Self> {
+        #[cfg(feature = "threadsafe")]
         assert!(thread::current().id() == unsafe { MAIN_THREAD_ID.unwrap() },
                 "ListIterator::new() must be called from the main thread.");
         let name     = str2cstring(list_name);

--- a/src/thread_facilities.rs
+++ b/src/thread_facilities.rs
@@ -298,7 +298,7 @@ fn main_thread_deinit() {
 ///
 #[deprecated(
     since = "0.2.6",
-    note = "This function is no longer necessary. Threadsaef features can be\
+    note = "This function is no longer necessary. Threadsafe features can be\
             turned off by specifying `features = []` in the Cargo.toml file \
             for the `hexchat-api` dependency.")]
 pub unsafe fn turn_off_threadsafe_features() {

--- a/src/threadsafe_context.rs
+++ b/src/threadsafe_context.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "threadsafe")]
 
 //! A thread-safe version of `Context`. The methods of these objects will 
 //! execute on the main thread of Hexchat. Invoking them is virutally the same 

--- a/src/threadsafe_context.rs
+++ b/src/threadsafe_context.rs
@@ -45,7 +45,7 @@ impl ThreadSafeContext {
     /// yield a wrapped `Context` for an unexpected channel.
     ///
     pub fn get() -> Option<Self> {
-        main_thread(|_| Context::get().map(Self::new)).get()
+        main_thread(|_| Context::get().map(Self::new)).get().unwrap()
     }
     
     /// Gets a `ThreadSafeContext` object associated with the given channel.
@@ -59,7 +59,7 @@ impl ThreadSafeContext {
         let data = (network.to_string(), channel.to_string());
         main_thread(move |_| {
             Context::find(&data.0, &data.1).map(Self::new)
-        }).get()
+        }).get().unwrap()
     }
 
     /// Prints the message to the `ThreadSafeContext` object's Hexchat context.
@@ -72,7 +72,7 @@ impl ThreadSafeContext {
             me.ctx.read().unwrap().as_ref()
                   .expect("Context dropped from threadsafe context.")
                   .print(&message)
-        }).get()
+        }).get().unwrap()
     }
     
     /// Prints without waiting for asynchronous completion. This will print
@@ -105,7 +105,7 @@ impl ThreadSafeContext {
             me.ctx.read().unwrap().as_ref()
                   .expect("Context dropped from threadsafe context.")
                   .command(&command)
-        }).get()
+        }).get().unwrap()
     }
 
     /// Gets information from the channel/window that the `ThreadSafeContext` 
@@ -118,7 +118,7 @@ impl ThreadSafeContext {
             me.ctx.read().unwrap().as_ref()
                   .expect("Context dropped from threadsafe context.")
                   .get_info(&info)
-        }).get()
+        }).get().unwrap()
     }
     
     /// Issues a print event to the context held by the `ThreadSafeContext` 
@@ -139,7 +139,7 @@ impl ThreadSafeContext {
             me.ctx.read().unwrap().as_ref()
                   .expect("Context dropped from threadsafe context.")
                   .emit_print(&data.0, var_args.as_slice())
-        }).get()
+        }).get().unwrap()
     }
     
     /// Gets a `ListIterator` from the context held by the `Context` object.
@@ -169,7 +169,7 @@ impl ThreadSafeContext {
                 Err(ContextError::ContextDropped(
                     "Context dropped from threadsafe context.".to_string()))
             }
-        }).get()
+        }).get().unwrap()
     }
 }
 

--- a/src/threadsafe_hexchat.rs
+++ b/src/threadsafe_hexchat.rs
@@ -34,7 +34,7 @@ impl ThreadSafeHexchat {
     pub fn print(&self, text: &str) {
         let text = text.to_string();
         let result = main_thread(move |hc| hc.print(&text));
-        result.get();
+        result.get().unwrap();
     }
     
     /// Invokes the Hexchat command specified by `command`.
@@ -44,7 +44,7 @@ impl ThreadSafeHexchat {
     pub fn command(&self, command: &str) {
         let command = command.to_string();
         let result = main_thread(move |hc| hc.command(&command));
-        result.get();
+        result.get().unwrap();
     }
     
     /// Returns a `ThreadSafeContext` object bound to the requested channel.
@@ -67,7 +67,7 @@ impl ThreadSafeHexchat {
         let data = (network.to_string(), channel.to_string());
         main_thread(move |hc| {
             hc.find_context(&data.0, &data.1).map(ThreadSafeContext::new)
-        }).get()
+        }).get().unwrap()
     }
 
     /// This should be invoked from the main thread. The context object returned
@@ -86,7 +86,7 @@ impl ThreadSafeHexchat {
         //self.hc.get_context().map(ThreadSafeContext::new)
         main_thread(|hc| {
             hc.get_context().map(ThreadSafeContext::new)
-        }).get()
+        }).get().unwrap()
     }
         
     /// Retrieves the info data with the given `id`. It returns None on failure
@@ -107,7 +107,7 @@ impl ThreadSafeHexchat {
         let id = id.to_string();
         main_thread(move |hc| {
             hc.get_info(&id)
-        }).get()
+        }).get().unwrap()
     }
     
     /// Creates an iterator for the requested Hexchat list. This is modeled
@@ -127,7 +127,7 @@ impl ThreadSafeHexchat {
         let list = list.to_string();
         main_thread(move |hc| {
             hc.list_get(&list).map(ThreadSafeListIterator::create)
-        }).get()
+        }).get().unwrap()
     }
 }
 

--- a/src/threadsafe_hexchat.rs
+++ b/src/threadsafe_hexchat.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "threadsafe")]
 
 //! A thread-safe wrapper for the `Hexchat` object. The methods of the object
 //! will execute on the Hexchat main thread when called from another thread.

--- a/src/threadsafe_list_iterator.rs
+++ b/src/threadsafe_list_iterator.rs
@@ -61,7 +61,7 @@ impl ThreadSafeListIterator {
                     list_iter: 
                         Arc::new(RwLock::new(Some(SendWrapper::new(list))))
                 })}
-        ).get()
+        ).get().unwrap()
     }
     
     /// Returns a vector of the names of the fields supported by the list
@@ -73,7 +73,7 @@ impl ThreadSafeListIterator {
             me.list_iter.read().unwrap().as_ref()
                         .expect("ListIterator dropped from threadsafe context.")
                         .get_field_names().to_vec()
-        }).get()
+        }).get().unwrap()
     }
     
     /// Constructs a vector of list items on the main thread all at once. The
@@ -85,7 +85,7 @@ impl ThreadSafeListIterator {
             me.list_iter.read().unwrap().as_ref()
                         .expect("ListIterator dropped from threadsafe context.")
                         .to_vec()
-        }).get()
+        }).get().unwrap()
     }
     
     /// Creates a `ListItem` from the field data at the current position in the
@@ -97,7 +97,7 @@ impl ThreadSafeListIterator {
             me.list_iter.read().unwrap().as_ref()
                         .expect("ListIterator dropped from threadsafe context.")
                         .get_item()
-        }).get()
+        }).get().unwrap()
     }
     
     /// Returns the value for the field of the requested name.
@@ -153,7 +153,7 @@ impl ThreadSafeListIterator {
                     "ListIterator dropped from threadsafe context."
                     .to_string()))
             }
-        }).get()
+        }).get().unwrap()
     }
 }
 
@@ -167,7 +167,7 @@ impl Iterator for ThreadSafeListIterator {
             } else {
                 None
             }
-        }).get()
+        }).get().unwrap()
     }
 }
 
@@ -178,7 +178,7 @@ impl Iterator for &ThreadSafeListIterator {
         let has_more = main_thread(move |_| {
             me.list_iter.write().unwrap().as_mut()
                         .map_or(false, |it| it.next().is_some())
-        }).get();
+        }).get().unwrap();
         if has_more {
             Some(self)
         } else {

--- a/src/threadsafe_list_iterator.rs
+++ b/src/threadsafe_list_iterator.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "threadsafe")]
 
 //! This module provides a thread-safe wrapper class for the Hexchat 
 //! `ListIterator`. The methods it provides can be invoked from threads other


### PR DESCRIPTION
The changes, while they don't seem to fix the issue, don't make it any worse. The approach theoretically should prevent some use cases from hanging Hexchat while threads may still be waiting on AsyncResult's.