### PR TITLE
Threadsafe flattened results

### DIFF
--- a/src/callback_data.rs
+++ b/src/callback_data.rs
@@ -1,5 +1,5 @@
 
-//! The `CallbackData` object holds all the information about a callback 
+//! The `CallbackData` object holds all the information about a callback
 //! needed to manage the `user_data` and  invoke it safely and correctly.
 //! The objects of this module are used internally. This file also contains
 //! type declarations for the Rust-facing callback signatures.
@@ -12,7 +12,7 @@ use core::mem;
 
 use UCallback::*;
 
-/// Holds the Rust-implemented function, or closure, of a registered Hexchat 
+/// Holds the Rust-implemented function, or closure, of a registered Hexchat
 /// callback.
 ///
 #[allow(dead_code)]
@@ -27,7 +27,7 @@ enum UCallback {
 }
 impl Default for UCallback {
     /// Supports `mem::take()` for the `TimerOnce` callback invocation.
-    /// The value of that callback is replaced with `OnceDone` when 
+    /// The value of that callback is replaced with `OnceDone` when
     /// `mem::take()` is performed on it in `timer_once_cb()`.
     fn default() -> Self { OnceDone }
 }
@@ -36,12 +36,12 @@ impl Default for UCallback {
 /// Pointers to instances of this struct are registered with the Hexchat
 /// callbacks. On the C-facing side, this is the `user_data` passed to the
 /// native callback wrappers (like `c_print_callback()`). When invoked by
-/// Hexchat, the native callbacks receive a pointer to a `user_data` 
-/// (`CallbackData`) object, which the wrapper then uses to invoke the 
-/// Rust-implemented callback held in the `UCallback` field below. The `data` 
+/// Hexchat, the native callbacks receive a pointer to a `user_data`
+/// (`CallbackData`) object, which the wrapper then uses to invoke the
+/// Rust-implemented callback held in the `UCallback` field below. The `data`
 /// field holds the user data registered for the Rust-facing callback, and is
 /// passed to it when invoked.
-pub (crate) 
+pub (crate)
 struct CallbackData {
     callback    : UCallback,
     data        : UserData,
@@ -51,10 +51,10 @@ struct CallbackData {
 impl CallbackData {
     /// Creates callback data for a regular command or server command.
     pub (crate)
-    fn new_command_data(callback : Box<Callback>, 
+    fn new_command_data(callback : Box<Callback>,
                         data     : UserData,
                         hook     : Hook
-                       ) -> Self 
+                       ) -> Self
     {
         let callback = Command(callback);
         CallbackData { callback, data, hook  }
@@ -62,7 +62,7 @@ impl CallbackData {
 
     /// Creates callback data for a print callback.
     pub (crate)
-    fn new_print_data(callback  : Box<PrintCallback>, 
+    fn new_print_data(callback  : Box<PrintCallback>,
                       data      : UserData,
                       hook      : Hook
                      ) -> Self
@@ -73,7 +73,7 @@ impl CallbackData {
 
     /// Creates callback data for a print attrs callback.
     pub (crate)
-    fn new_print_attrs_data(callback : Box<PrintAttrsCallback>, 
+    fn new_print_attrs_data(callback : Box<PrintAttrsCallback>,
                             data     : UserData,
                             hook     : Hook
                            ) -> Self
@@ -84,7 +84,7 @@ impl CallbackData {
 
     /// Creates callback data for a timer callback.
     pub (crate)
-    fn new_timer_data(callback : Box<TimerCallback>, 
+    fn new_timer_data(callback : Box<TimerCallback>,
                       data     : UserData,
                       hook     : Hook
                      ) -> Self
@@ -92,7 +92,7 @@ impl CallbackData {
         let callback = Timer(callback);
         CallbackData { callback, data, hook }
     }
-    
+
     #[allow(dead_code)]
     pub (crate)
     fn new_timer_once_data(callback : Box<TimerCallbackOnce>,
@@ -104,10 +104,10 @@ impl CallbackData {
         CallbackData { callback, data, hook }
     }
 
-    
+
     /// Creates callback data for a fd callback.
     pub (crate)
-    fn new_fd_data(callback : Box<FdCallback>, 
+    fn new_fd_data(callback : Box<FdCallback>,
                    data     : UserData,
                    hook     : Hook
                   ) -> Self
@@ -117,13 +117,13 @@ impl CallbackData {
     }
 
     /// Returns a reference to the Rust-facing `user_data` that was
-    /// registered with the callback.    
+    /// registered with the callback.
     #[inline]
     pub (crate)
     fn get_user_data(&self) -> &UserData {
         &self.data
     }
-    
+
     /// Returns the `user_data` held by the `CallbackData` object, passing
     /// ownership to the caller. The data field in the `CallbackData` object is
     /// replaced with `NoData`.
@@ -138,9 +138,9 @@ impl CallbackData {
     #[inline]
     pub (crate)
     unsafe fn command_cb(&mut self,
-                         hc       : &Hexchat, 
-                         word     : &[String], 
-                         word_eol : &[String], 
+                         hc       : &Hexchat,
+                         word     : &[String],
+                         word_eol : &[String],
                          ud       : &UserData
                         ) -> Eat
     {
@@ -150,17 +150,17 @@ impl CallbackData {
             panic!("Invoked wrong type in CallbackData.");
         }
     }
-    
+
     /// Invokes the callback held in the `callback` field. This is invoked by
     /// `c_print_callback()` which is the C-side registered callback for each
     /// print callback.
     #[inline]
     pub (crate)
     unsafe fn print_cb(&mut self,
-                       hc       : &Hexchat, 
-                       word     : &[String], 
+                       hc       : &Hexchat,
+                       word     : &[String],
                        ud       : &UserData
-                      ) -> Eat 
+                      ) -> Eat
     {
         if let Print(callback) = &mut self.callback {
             (*callback)(hc, word, ud)
@@ -168,7 +168,7 @@ impl CallbackData {
             panic!("Invoked wrong type in CallbackData.");
         }
     }
-    
+
     /// Invokes the callback held in the `callback` field. This is invoked by
     /// `c_print_attrs_callback()`.
     #[inline]
@@ -186,7 +186,7 @@ impl CallbackData {
             panic!("Invoked wrong type in CallbackData.");
         }
     }
-    
+
     /// Invokes the callback held in the `callback` field. This is invoked by
     /// c_timer_callback()`.
     #[inline]
@@ -228,16 +228,16 @@ impl CallbackData {
             },
         }
     }
-    
+
 
     /// Invokes the callback held in the `callback` field. This is invoked by
     /// c_fd_callback()`.
     #[inline]
     pub (crate)
-    unsafe fn fd_cb(&mut self, 
-                    hc    : &Hexchat, 
-                    fd    : i32, 
-                    flags : i32, 
+    unsafe fn fd_cb(&mut self,
+                    hc    : &Hexchat,
+                    fd    : i32,
+                    flags : i32,
                     ud    : &UserData) -> Eat
     {
         if let FD(callback) = &mut self.callback {
@@ -248,9 +248,9 @@ impl CallbackData {
     }
 }
 
-/// The Rust-facing function signature corresponding to the C-facing  
+/// The Rust-facing function signature corresponding to the C-facing
 /// `C_Callback`. Note that, unlike the C API, the Rust-facing callback
-/// signatures include a reference to the Hexchat pointer for 
+/// signatures include a reference to the Hexchat pointer for
 /// convenience.
 pub (crate)
 type Callback = dyn FnMut(&Hexchat,
@@ -259,47 +259,47 @@ type Callback = dyn FnMut(&Hexchat,
                           &UserData
                          ) -> Eat;
 
-/// The Rust-facing function signature corresponding to the C-facing  
+/// The Rust-facing function signature corresponding to the C-facing
 /// `C_PrintCallback`. Note that, unlike the C API, the Rust-facing callback
-/// signatures include a reference to the Hexchat pointer for 
+/// signatures include a reference to the Hexchat pointer for
 /// convenience.
 pub (crate)
-type PrintCallback 
+type PrintCallback
               = dyn FnMut(&Hexchat,
                           &[String],
                           &UserData
                          ) -> Eat;
 
-/// The Rust-facing function signature corresponding to the C-facing  
+/// The Rust-facing function signature corresponding to the C-facing
 /// `C_PrintAttrsCallback`. Note that, unlike the C API, the Rust-facing callback
-/// signatures include a reference to the Hexchat pointer for 
+/// signatures include a reference to the Hexchat pointer for
 /// convenience.
 pub (crate)
-type PrintAttrsCallback 
+type PrintAttrsCallback
               = dyn FnMut(&Hexchat,
                           &[String],
                           &EventAttrs,
                           &UserData
                          ) -> Eat;
 
-/// The Rust-facing function signature corresponding to the C-facing  
+/// The Rust-facing function signature corresponding to the C-facing
 /// `C_TimerCallback`. Note that, unlike the C API, the Rust-facing callback
-/// signatures include a reference to the Hexchat pointer for 
+/// signatures include a reference to the Hexchat pointer for
 /// convenience.
 pub (crate)
-type TimerCallback 
+type TimerCallback
               = dyn FnMut(&Hexchat, &UserData) -> i32;
-              
+
 pub (crate)
-type TimerCallbackOnce 
+type TimerCallbackOnce
               = dyn FnOnce(&Hexchat, &UserData) -> i32;
 
 
-/// The Rust-facing function signature corresponding to the C-facing  
+/// The Rust-facing function signature corresponding to the C-facing
 /// `C_FdCallback`. Note that, unlike the C API, the Rust-facing callback
-/// signatures include a reference to the Hexchat pointer for 
+/// signatures include a reference to the Hexchat pointer for
 /// convenience.
 pub (crate)
-type FdCallback 
+type FdCallback
               = dyn FnMut(&Hexchat, i32, i32, &UserData) -> Eat;
-              
+

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -18,7 +18,7 @@ pub enum ChanFlag {
     SCROLLBACK          = 0x2000,
     SCROLLBACK_UNSET    = 0x4000,
     STRIP_COLORS        = 0x8000,
-    STRIP_COLORS_UNSET  =0x10000,    
+    STRIP_COLORS_UNSET  =0x10000,
 }
 
 /// Channel types.
@@ -27,7 +27,7 @@ pub enum ChanType {
     CHANNEL                  = 2,
     DIALOG                   = 3,
     NOTICE                   = 4,
-    SNOTICE                  = 5,    
+    SNOTICE                  = 5,
 }
 
 /// DCC status values.

--- a/src/context.rs
+++ b/src/context.rs
@@ -266,6 +266,7 @@ pub enum ContextError {
     OperationFailed(String),
     ContextDropped(String),
     ThreadSafeOperationFailed(String),
+    ListNotFound(String),
 }
 
 impl error::Error for ContextError {}
@@ -285,6 +286,9 @@ impl fmt::Display for ContextError {
             },
             ThreadSafeOperationFailed(reason) => {
                 write!(f, "ThreadSafeOperationFailed(\"{}\")", reason)
+            },
+            ListNotFound(list) => {
+                write!(f, "ListNotFound(\"{}\")", list)
             },
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -265,6 +265,7 @@ pub enum ContextError {
     AcquisitionFailed(String, String),
     OperationFailed(String),
     ContextDropped(String),
+    ThreadSafeOperationFailed(String),
 }
 
 impl error::Error for ContextError {}
@@ -281,6 +282,9 @@ impl fmt::Display for ContextError {
             },
             ContextDropped(reason) => {
                 write!(f, "ContextDropped(\"{}\")", reason)
+            },
+            ThreadSafeOperationFailed(reason) => {
+                write!(f, "ThreadSafeOperationFailed(\"{}\")", reason)
             },
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -274,7 +274,9 @@ impl error::Error for ContextError {}
 
 impl fmt::Display for ContextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        let mut s = format!("{:?}", self);
+        s.retain(|c| c != '"');
+        write!(f, "{}", s)
     }
 }
 /*

--- a/src/context.rs
+++ b/src/context.rs
@@ -274,27 +274,7 @@ impl error::Error for ContextError {}
 
 impl fmt::Display for ContextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            AcquisitionFailed(network, channel) => {
-                write!(f, "AcquisitionFailed(\"{}\", \"{}\")",
-                          network, channel)
-            },
-            OperationFailed(reason) => {
-                write!(f, "OperationFailed(\"{}\")", reason)
-            },
-            ContextDropped(reason) => {
-                write!(f, "ContextDropped(\"{}\")", reason)
-            },
-            ThreadSafeOperationFailed(reason) => {
-                write!(f, "ThreadSafeOperationFailed(\"{}\")", reason)
-            },
-            ListNotFound(list) => {
-                write!(f, "ListNotFound(\"{}\")", list)
-            },
-            InfoNotFound(info) => {
-                write!(f, "InfoNotFound(\"{}\")", info)
-            },
-        }
+        write!(f, "{:?}", self)
     }
 }
 /*

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,16 +36,16 @@ struct ContextData {
 }
 /// Any channel in Hexchat has an associated IRC network name and channel name.
 /// The network name and channel name are closely associated with the Hexchat
-/// concept of contexts. Hexchat contexts can also be thought of as the 
+/// concept of contexts. Hexchat contexts can also be thought of as the
 /// tabs, or windows, open in the UI that have the user joined to their various
-/// "chat rooms". To access a specific chat window in Hexchat, its context 
+/// "chat rooms". To access a specific chat window in Hexchat, its context
 /// can be acquired and used. This library's `Context` objects represent the
-/// Hexchat contexts and can be used to interact with the specific 
+/// Hexchat contexts and can be used to interact with the specific
 /// channels/windows/tabs that he user has open. For instance if your plugin
 /// needs to output only to specific channels, rather than the default window
 /// (which is the one currently open) - it can acquire the appropriate context
 /// using `Context::find("some-network", "some-channel")`, and use the object
-/// returned to invoke a command, `context.command("SAY hello!")`, or print, 
+/// returned to invoke a command, `context.command("SAY hello!")`, or print,
 /// `context.print("Hello!")`, or perform other operations.
 ///
 #[derive(Debug, Clone)]
@@ -58,6 +58,7 @@ impl Context {
     /// the requested network/channel, if it exists. The object will be
     /// returned as a `Some<Context>` if the context is found, or `None` if
     /// not.
+    /// 
     pub fn find(network: &str, channel: &str) -> Option<Self> {
         #[cfg(feature = "threadsafe")]
         assert!(thread::current().id() == unsafe { MAIN_THREAD_ID.unwrap() },
@@ -89,6 +90,7 @@ impl Context {
     /// context (window/tab, channel/network) open on the user's screen. A
     /// `Result<Context, ()>` is returned with either the context, or an
     /// error result if it coulnd't be obtained.
+    /// 
     pub fn get() -> Option<Self> {
         #[cfg(feature = "threadsafe")]
         assert!(thread::current().id() == unsafe { MAIN_THREAD_ID.unwrap() },
@@ -124,6 +126,7 @@ impl Context {
     /// So `Context` objects need to reacquire the pointer for each command
     /// invocation. If successful, `Ok(ptr)` is returned with the pointer value;
     /// `AcquisitionFailed(network, channel)` otherwise.
+    /// 
     #[inline]
     fn acquire(&self) -> Result<*const hexchat_context, ContextError> {
         let data = &*self.data;
@@ -220,9 +223,6 @@ impl Context {
     }
 
     /// Gets a `ListIterator` from the context held by the `Context` object.
-    /// If the list doesn't exist, the `OK()` result will contain `None`;
-    /// otherwise it will hold the `listIterator` object for the requested
-    /// list.
     ///
     pub fn list_get(&self, list: &str)
         -> Result<ListIterator, ContextError>
@@ -251,15 +251,23 @@ impl fmt::Display for Context {
 
 /// The `Context` functions may encounter an error when invoked depending on
 /// whether the network name and channel name they're bound to are currently
-/// valid. 
+/// valid.
 /// # Variants
 /// * `AcquisitionFailed`   - The function was unable to acquire the desired
 ///                           context associated with its network and channel
 ///                           names.
 /// * `OperationFailed`     - The context acquisition succeeded, but there is
 ///                           some problem with the action being performed,
-///                           for instance the requested list for 
+///                           for instance the requested list for
 ///                           `ctx.get_listiter("foo")` doesn't exist.
+/// * `ContextDropped`      - The context object was dropped.
+/// * `ThreadSafeOperationFailed` 
+///                         - This can happen when a `ThreadSafeContext` or 
+///                          `ThreadSafeListIterator` object is used while 
+///                          the plugin is unloading.
+/// * `ListNotFound`        - The requested list doesn't exist.
+/// * `InfoNotFound`        - The requested info doesn't exist.
+/// 
 #[derive(Debug, Clone)]
 pub enum ContextError {
     AcquisitionFailed(String, String),

--- a/src/hexchat.rs
+++ b/src/hexchat.rs
@@ -3,7 +3,7 @@
 //! loads this library, the Hexchat pointer is stored and used by casting it
 //! to the struct contained in this file. These native function pointers are
 //! private to this crate, and a more Rust-friendly API is provided through
-//! this Hexchat interface. 
+//! this Hexchat interface.
 
 use libc::{c_int, c_char, c_void, time_t};
 use std::{error, ptr};
@@ -33,9 +33,9 @@ const MAX_PREF_VALUE_SIZE: usize =  512;
 
 /// Value specified on the [Hexchat Plugin Interface web page]
 /// (https://hexchat.readthedocs.io/en/latest/plugins.html).
-const MAX_PREF_LIST_SIZE : usize = 4096; 
+const MAX_PREF_LIST_SIZE : usize = 4096;
 
-// hexchat_send_modes, hexchat_event_attrs_free, pluginpref_delete, 
+// hexchat_send_modes, hexchat_event_attrs_free, pluginpref_delete,
 
 /// The priorty for a given callback invoked by Hexchat.
 pub enum Priority {
@@ -72,9 +72,9 @@ pub enum StripFlags {
 
 /// This is the rust-facing Hexchat API. Each method has a corresponding
 /// C function pointer which they wrap and marshal data/from.
-/// 
+///
 impl Hexchat {
-    
+
     /// Returns a thread-safe wrapper for `Hexchat` that exposes thread-safe
     /// methods wrapping several of `Hexchat`s methods.
     ///
@@ -127,9 +127,9 @@ impl Hexchat {
                                     pri         : Priority,
                                     callback    : F,
                                     help        : &str,
-                                    user_data   : UserData) 
+                                    user_data   : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, &[String], &[String], &UserData)
            -> Eat
     {
@@ -139,11 +139,11 @@ impl Hexchat {
                                       Box::new(callback),
                                       user_data,
                                       hook.clone()));
-                                  
+
         let ud   = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
-        
+
         let help = if !help.is_empty() {
             help
         } else {
@@ -186,21 +186,21 @@ impl Hexchat {
                                    name        : &str,
                                    pri         : Priority,
                                    callback    : F,
-                                   user_data   : UserData) 
+                                   user_data   : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, &[String], &[String], &UserData)
            -> Eat
     {
         let hook = Hook::new();
         let ud   = Box::new(
-                    CallbackData::new_command_data( 
+                    CallbackData::new_command_data(
                                       Box::new(callback),
                                       user_data,
                                       hook.clone()
                                   ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
         let name = str2cstring(name);
         unsafe {
@@ -233,20 +233,20 @@ impl Hexchat {
                                   event_name  : &str,
                                   pri         : Priority,
                                   callback    : F,
-                                  user_data   : UserData) 
+                                  user_data   : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, &[String], &UserData) -> Eat
     {
         let hook = Hook::new();
         let ud   = Box::new(
-                    CallbackData::new_print_data( 
+                    CallbackData::new_print_data(
                                       Box::new(callback),
                                       user_data,
                                       hook.clone()
                                   ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
         let event_name = str2cstring(event_name);
         unsafe {
@@ -281,9 +281,9 @@ impl Hexchat {
                                         name        : &str,
                                         pri         : Priority,
                                         callback    : F,
-                                        user_data   : UserData) 
+                                        user_data   : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, &[String], &EventAttrs, &UserData)
            -> Eat
     {
@@ -295,7 +295,7 @@ impl Hexchat {
                                       hook.clone()
                                   ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
         let name = str2cstring(name);
         unsafe {
@@ -325,9 +325,9 @@ impl Hexchat {
     pub fn hook_timer<F: 'static>(&self,
                                   timeout   : i64,
                                   callback  : F,
-                                  user_data : UserData) 
+                                  user_data : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, &UserData) -> i32
     {
         let hook = Hook::new();
@@ -337,9 +337,9 @@ impl Hexchat {
                                             hook.clone()
                                         ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
-        
+
         unsafe {
             hook.set((self.c_hook_timer)(self,
                                          timeout as c_int,
@@ -366,7 +366,7 @@ impl Hexchat {
     fn hook_timer_once(&self,
                        timeout   : i64,
                        callback  : Box<TimerCallbackOnce>,
-                       user_data : UserData) 
+                       user_data : UserData)
         -> Hook
     {
         // TODO - Put the function signatures somewhere logical (?)
@@ -378,9 +378,9 @@ impl Hexchat {
                                             hook.clone()
                                         ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
-        
+
         unsafe {
             hook.set((self.c_hook_timer)(self,
                                          timeout as c_int,
@@ -388,16 +388,16 @@ impl Hexchat {
                                          ud));
         }
         hook
-    }                                   
+    }
 
     /// Registers a callback to be called after the given timeout.
     pub fn hook_fd<F: 'static>(&self,
                                fd        : i32,
                                flags     : i32,
                                callback  : F,
-                               user_data : UserData) 
+                               user_data : UserData)
         -> Hook
-    where 
+    where
         F: FnMut(&Hexchat, i32, i32, &UserData) -> Eat
     {
         let hook = Hook::new();
@@ -407,9 +407,9 @@ impl Hexchat {
                                             hook.clone()
                                         ));
         let ud = Box::into_raw(ud) as *mut c_void;
-        
+
         hook.set_cbd(ud);
-        
+
         unsafe {
             hook.set((self.c_hook_fd)(self,
                                       fd as c_int,
@@ -450,7 +450,7 @@ impl Hexchat {
         self.emit_print_impl(0, &event_attrs, event_name, var_args)
     }
 
-    
+
     /// Issues one of the Hexchat IRC events. The command works for any of the
     /// events listed in Settings > Text Events dialog.
     /// # Arguments
@@ -463,7 +463,7 @@ impl Hexchat {
     pub fn emit_print_attrs(&self,
                             event_attrs : &EventAttrs,
                             event_name  : &str,
-                            var_args    : &[&str]) 
+                            var_args    : &[&str])
         -> Result<(), HexchatError>
     {
         self.emit_print_impl(1, event_attrs, event_name, var_args)
@@ -485,25 +485,25 @@ impl Hexchat {
                        ver          : i32,
                        event_attrs  : &EventAttrs,
                        event_name   : &str,
-                       var_args     : &[&str]) 
+                       var_args     : &[&str])
         -> Result<(), HexchatError>
     {
         let mut args   = vec![];
         let     name   = str2cstring(event_name);
         let     va_len = var_args.len();
-        
-        // We don't know if there are 6 items in var_args - so Clippy's 
+
+        // We don't know if there are 6 items in var_args - so Clippy's
         // suggestion would fail. This range loop is fine.
         #[allow(clippy::needless_range_loop)]
         for i in 0..6 {
             args.push(str2cstring(if i < va_len { var_args[i] } else { "" }));
         }
-       
+
         // TODO - If empty strings don't suffice as a nop param, then construct
         //        another vector containing pointers and pad with nulls.
         unsafe {
             use HexchatError::*;
-            
+
             if ver == 0 {
                 let result = (self.c_emit_print)(
                                     self,
@@ -596,7 +596,7 @@ impl Hexchat {
     }
 
     /// Returns a `Context` object bound to the requested server/channel.
-    /// The object provides methods like `print()` that will execute the 
+    /// The object provides methods like `print()` that will execute the
     /// Hexchat print command in that tab/window related to the context.
     /// The `Context::find()` can also be invoked to find a context.
     /// # Arguments
@@ -644,10 +644,10 @@ impl Hexchat {
         let info  = unsafe { (self.c_get_info)(self, idstr.as_ptr()) };
         if !info.is_null() {
             match id {
-                "win_ptr"  | "gtkwin_ptr"  => { 
+                "win_ptr"  | "gtkwin_ptr"  => {
                     Some((info as u64).to_string())
                 },
-                _ => { 
+                _ => {
                     Some(pchar2string(info))
                 },
             }
@@ -698,9 +698,9 @@ impl Hexchat {
     pub fn list_get(&self, name: &str) -> Option<ListIterator> {
         ListIterator::new(name)
     }
-    
+
     /// Writes a variable name and value to a configuration file maintained
-    /// by Hexchat for your plugin. These can be accessed later using 
+    /// by Hexchat for your plugin. These can be accessed later using
     /// `pluginpref_get()`. *A character representing the type of the pref is
     /// prepended to the value output to the config file. `pluginpref_get()`
     /// uses this when reading back values from the config file to return the
@@ -749,7 +749,7 @@ impl Hexchat {
         } else { None }
     }
 
-    /// Returns a list of all the plugin pref variable names your plugin 
+    /// Returns a list of all the plugin pref variable names your plugin
     /// registered using `pluginpref_set()`. `pluginpref_get()` can be invoked
     /// with each item to get their values.
     /// # Returns
@@ -796,7 +796,7 @@ impl Hexchat {
                          filename : &str,
                          name     : &str,
                          desc     : &str,
-                         version  : &str) 
+                         version  : &str)
         -> Plugin
     {
         Plugin::new(filename, name, desc, version)
@@ -875,7 +875,7 @@ impl PrefValue {
     }
 }
 
-// Apply the same attribute to all items in the block, but don't compile it as 
+// Apply the same attribute to all items in the block, but don't compile it as
 // an actual block.
 macro_rules! apply_attrib {
     (#![$attr:meta] $( $it:item )*) => { $( #[$attr] $it )* }
@@ -925,7 +925,7 @@ type C_FDCallback    = extern "C"
 }
 
 /// Mirrors the C struct for `hexchat_event_attrs`. It holds the timestamps
-/// for the callback invocations for callbacks registered using 
+/// for the callback invocations for callbacks registered using
 /// `hexchat_print_attrs()`, and similar commands.
 #[repr(C)]
 pub struct EventAttrs {

--- a/src/hexchat.rs
+++ b/src/hexchat.rs
@@ -950,12 +950,7 @@ impl error::Error for HexchatError {}
 
 impl fmt::Display for HexchatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use HexchatError::*;
-        match self {
-            CommandFailed(message) => {
-                write!(f, "CommandFailed(\"{}\")", message)
-            },
-        }
+        write!(f, "{:?}", self)
     }
 }
 /*

--- a/src/hexchat.rs
+++ b/src/hexchat.rs
@@ -950,7 +950,9 @@ impl error::Error for HexchatError {}
 
 impl fmt::Display for HexchatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        let mut s = format!("{:?}", self);
+        s.retain(|c| c != '"');
+        write!(f, "{}", s)
     }
 }
 /*

--- a/src/hexchat_callbacks.rs
+++ b/src/hexchat_callbacks.rs
@@ -19,7 +19,7 @@ use crate::utils::*;
 pub (crate)
 extern "C" fn c_callback(word        : *const *const c_char,
                          word_eol    : *const *const c_char,
-                         user_data   : *mut c_void) 
+                         user_data   : *mut c_void)
     -> c_int
 {
     catch_unwind(|| {
@@ -40,12 +40,12 @@ extern "C" fn c_callback(word        : *const *const c_char,
 /// `user_data`.
 pub (crate)
 extern "C" fn c_print_callback(word      : *const *const c_char,
-                               user_data : *mut c_void) 
+                               user_data : *mut c_void)
     -> c_int
 {
     catch_unwind(|| {
         let word = argv2svec(word, 1);
-        
+
         unsafe {
             let cd = user_data as *mut CallbackData;
             let hc = &*PHEXCHAT;
@@ -60,12 +60,12 @@ extern "C" fn c_print_callback(word      : *const *const c_char,
 pub (crate)
 extern "C" fn c_print_attrs_callback(word      : *const *const c_char,
                                      attrs     : *const EventAttrs,
-                                     user_data : *mut c_void) 
+                                     user_data : *mut c_void)
     -> c_int
 {
     catch_unwind(|| {
         let word = argv2svec(word, 1);
-        
+
         unsafe {
             let cd = user_data as *mut CallbackData;
             let hc = &*PHEXCHAT;
@@ -108,7 +108,7 @@ extern "C" fn c_timer_callback_once(user_data: *mut c_void) -> c_int {
 /// callbacks.
 pub (crate)
 extern "C" fn c_fd_callback(fd: c_int, flags: c_int, user_data: *mut c_void)
-    -> c_int 
+    -> c_int
 {
     catch_unwind(|| {
         unsafe {

--- a/src/hexchat_entry_points.rs
+++ b/src/hexchat_entry_points.rs
@@ -2,11 +2,11 @@
 //! This module holds the DLL entry points for this plugin library.
 //! These exported functions are what Hexchat links to directly when the
 //! plugin is loaded.
-//! 
+//!
 //! These functions register the plugin info with Hexchat and set up to "catch"
 //! any panics that Rust-side callbacks might "raise" during execution.
 //! Panics are displayed in the currently active Hexchat window/context.
-//! The debug build of the library will include a stack trace in the error 
+//! The debug build of the library will include a stack trace in the error
 //! message.
 
 #[cfg(debug_assertions)]
@@ -82,16 +82,16 @@ pub(crate) static mut PHEXCHAT: *const Hexchat = null::<Hexchat>();
 ///
 #[macro_export]
 macro_rules! dll_entry_points {
- 
+
     ( $info:ident, $init:ident, $deinit:ident ) => {
         #[no_mangle]
-        pub extern "C"    
+        pub extern "C"
         fn hexchat_plugin_get_info(name     : *mut *const i8,
                                    desc     : *mut *const i8,
                                    version  : *mut *const i8,
-                                   reserved : *mut *const i8) 
+                                   reserved : *mut *const i8)
         {
-            hexchat_api::lib_get_info(name,    
+            hexchat_api::lib_get_info(name,
                                       desc,
                                       version,
                                       Box::new($info));
@@ -104,9 +104,9 @@ macro_rules! dll_entry_points {
                                version   : *mut *const i8
                               ) -> i32
         {
-            hexchat_api::lib_hexchat_plugin_init(hexchat, 
+            hexchat_api::lib_hexchat_plugin_init(hexchat,
                                                  name,
-                                                 desc,   
+                                                 desc,
                                                  version,
                                                  Box::new($init),
                                                  Box::new($info))
@@ -168,10 +168,10 @@ impl PluginInfo {
         let sname        = NonNull::from(&boxed.name);
         let sversion     = NonNull::from(&boxed.version);
         let sdescription = NonNull::from(&boxed.description);
-        
+
         unsafe {
             let mut_ref: Pin<&mut PluginInfoData> = Pin::as_mut(&mut boxed);
-            let unchecked = Pin::get_unchecked_mut(mut_ref); 
+            let unchecked = Pin::get_unchecked_mut(mut_ref);
             unchecked.pname        = sname;
             unchecked.pversion     = sversion;
             unchecked.pdescription = sdescription;
@@ -206,7 +206,7 @@ pub fn lib_hexchat_plugin_init(hexchat   : &'static Hexchat,
                                desc      : *mut *const c_char,
                                version   : *mut *const c_char,
                                init_cb   : Box<InitFn>,
-                               info_cb   : Box<InfoFn>) 
+                               info_cb   : Box<InfoFn>)
     -> i32
 {
     // Store the global Hexchat pointer.
@@ -217,11 +217,11 @@ pub fn lib_hexchat_plugin_init(hexchat   : &'static Hexchat,
     lib_get_info(name, desc, version, info_cb);
 
     // Invoke client lib's init function.
-    catch_unwind(|| { 
+    catch_unwind(|| {
         Hook::init();
         #[cfg(feature = "threadsafe")]
         main_thread_init();
-        init_cb(hexchat) 
+        init_cb(hexchat)
     }).unwrap_or(0)
 }
 
@@ -229,12 +229,12 @@ pub fn lib_hexchat_plugin_init(hexchat   : &'static Hexchat,
 /// call the deinitialization function that was registered using the
 /// `dll_entry_points()` macro. It will also unhook all the callbacks
 /// currently registered forcing them, and their closure state, to drop and
-/// thus clean up. Plugin authors should not call this - it's only public 
+/// thus clean up. Plugin authors should not call this - it's only public
 /// because `dll_entry_points()` generates code that needs this.
 ///
 #[doc(hidden)]
-pub fn lib_hexchat_plugin_deinit(hexchat  : &'static Hexchat, 
-                                 callback : Box<DeinitFn>) 
+pub fn lib_hexchat_plugin_deinit(hexchat  : &'static Hexchat,
+                                 callback : Box<DeinitFn>)
     -> i32
 {
     let result = catch_unwind(|| {
@@ -246,14 +246,14 @@ pub fn lib_hexchat_plugin_deinit(hexchat  : &'static Hexchat,
 
         // Call user's deinit().
         let retval = callback(hexchat);
-        
+
         // Cause the callback_data objects to drop and clean up.
-        Hook::deinit();   
-        
+        Hook::deinit();
+
         // Destruct the info struct.
         unsafe { PLUGIN_INFO = None; }
-        
-        retval     
+
+        retval
     }).unwrap_or(0);
     // Final clean up on unload - drop the hook closure.
     let _ = panic::take_hook();
@@ -287,8 +287,8 @@ pub fn lib_get_info(name     : *mut *const c_char,
     }
 }
 
-/// Sets the panic hook so panic info will be printed to the active Hexchat 
-/// window. The debug build includes a stack trace using  
+/// Sets the panic hook so panic info will be printed to the active Hexchat
+/// window. The debug build includes a stack trace using
 /// [Backtrace](https://crates.io/crates/backtrace)
 fn set_panic_hook(hexchat: &'static Hexchat) {
     panic::set_hook(Box::new(move |panic_info| {
@@ -313,7 +313,7 @@ fn set_panic_hook(hexchat: &'static Hexchat) {
                          plugin_name,
                          location.file(),
                          location.line()));
-                        
+
             #[cfg(debug_assertions)]
             { loc = format!("{}:{:?}", location.file(), location.line()); }
         }
@@ -325,7 +325,7 @@ fn set_panic_hook(hexchat: &'static Hexchat) {
             let mut end   = 0;
             let     bt    = Backtrace::new();
             let     btstr = format!("{:?}", bt);
-            
+
             for line in btstr.lines() {
                 let line  = String::from(line);
                 if begin == 0 && !loc.is_empty() && line.contains(&loc) {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -3,14 +3,14 @@
 //! with Hexchat. The Rust-style hook can be used to unhook commands directly
 //! via its `unhook()` function. This object protects against attempts to
 //! unhook the same callback more than once, which can crash Hexchat.
-//! 
+//!
 //! The `unhook()` function returns the user_data that was registered with
 //! the associated callback, passing ownership to the caller. Invoking
 //! `unhook()` more than once returns `None`.
-//! 
+//!
 //! The hooks can be cloned. Internally, clones safely share the same hook
 //! pointer. When hooks go out of scope, they do not remove their associated
-//! commands. Hooks can be ignored by the plugin if there is no need to 
+//! commands. Hooks can be ignored by the plugin if there is no need to
 //! unhook commands. The most relevant use of a hook could be to cancel
 //! timer callbacks.
 
@@ -25,7 +25,7 @@ use crate::callback_data::*;
 use crate::hexchat_entry_points::PHEXCHAT;
 use crate::user_data::*;
 
-/// A synchronized global list of the hooks. This gets initialized when a 
+/// A synchronized global list of the hooks. This gets initialized when a
 /// plugin is loaded from within the `lib_hexchat_plugin_init()` function
 /// before the plugin author's registered init function is invoked.
 ///
@@ -38,7 +38,7 @@ struct HookData {
     cbd_box_ptr : *const c_void,
 }
 
-/// A wrapper for Hexchat callback hooks. These hooks are returned when 
+/// A wrapper for Hexchat callback hooks. These hooks are returned when
 /// registering callbacks and can be used to unregister (unhook) them.
 /// `Hook`s can be cloned to share a reference to the same callback hook.
 ///
@@ -55,7 +55,7 @@ impl Hook {
     ///
     pub (crate) fn new() -> Self {
 
-        let hook = Hook { 
+        let hook = Hook {
             data: Arc::new(
                     RwLock::new(
                         Some(
@@ -65,24 +65,24 @@ impl Hook {
                                     cbd_box_ptr : null::<c_void>(),
                         })))),
         };
-                   
+
         if let Some(hook_list_rwlock) = unsafe { &HOOK_LIST } {
             // Acquire global hook list write lock.
             let wlock     = hook_list_rwlock.write();
             let hook_list = &mut *wlock.unwrap();
-            
+
             // Clean up dead hooks.
-            hook_list.retain(|h| 
+            hook_list.retain(|h|
                 !h.data.read().unwrap().as_ref().unwrap().hook_ptr.is_null()
             );
-            
+
             // Store newly created hook in global list.
             hook_list.push(hook.clone());
         }
 
         hook
     }
-    
+
     /// Sets the value of the internal hook pointer. This is used by the hooking
     /// functions in hexchat.rs.
     ///
@@ -109,28 +109,28 @@ impl Hook {
     }
 
     /// Unhooks the related callback from Hexchat. The user_data object is
-    /// returned. Subsequent calls to `unhook()` will return `None`. The 
+    /// returned. Subsequent calls to `unhook()` will return `None`. The
     /// callback that was registered with Hexchat will be unhooked and dropped.
     /// Ownership of the `user_data` will be passed to the caller.
     /// # Returns
     /// * The user data that was registered with the callback using one of the
-    ///   hexchat hook functions. 
+    ///   hexchat hook functions.
     ///
     pub fn unhook(&self) -> UserData {
         unsafe {
             if let Some(hl_rwlock) = &HOOK_LIST {
                 let _rlock = hl_rwlock.read();
-                
+
                 let ptr_data = &mut self.data.write().unwrap();
-                
+
                 // Determine if the Hook is still alive (non-null ptr).
                 if !ptr_data.as_ref().unwrap().hook_ptr.is_null() {
-                
+
                     // Unhook the callback.
                     let hc = &*PHEXCHAT;
                     let hp = ptr_data.as_ref().unwrap().hook_ptr;
                     let _  = (hc.c_unhook)(hc, hp);
-                    
+
                     // ^ _ should be our user_data, but we can't rely on Hexchat
                     // to return a valid user_data pointer on unload, so we have
                     // to maintain it ourselves.
@@ -142,8 +142,8 @@ impl Hook {
                     let cd = ptr_data.as_ref().unwrap().cbd_box_ptr;
                     let cd = &mut (*(cd as *mut CallbackData));
                     let cd = &mut Box::from_raw(cd);
-                    
-                    // Give the caller the `user_data` the plugin registered 
+
+                    // Give the caller the `user_data` the plugin registered
                     // with the callback.
                     return cd.take_data();
                 }
@@ -152,7 +152,7 @@ impl Hook {
         }
     }
 
-    /// Called automatically within `lib_hexchat_plugin_init()` when a plugin is 
+    /// Called automatically within `lib_hexchat_plugin_init()` when a plugin is
     /// loaded. This initializes the synchronized global static hook list.
     ///
     pub (crate) fn init() {
@@ -160,11 +160,11 @@ impl Hook {
             HOOK_LIST = Some(RwLock::new(Vec::new()));
         }
     }
-    
+
     /// Called when a plugin is unloaded by Hexchat. This happens when the user
     /// opens the "Plugins and Scripts" dialog and unloads/reloads the plugin,
     /// or the user issues one of the slash "/" commands to perform the same
-    /// operation. This function iterates over each hook, calling their 
+    /// operation. This function iterates over each hook, calling their
     /// `unhook()` method which grabs ownership of the `CallbackData` objects
     /// and drops them as they go out of scope ensuring their destructors
     /// are called.
@@ -178,7 +178,7 @@ impl Hook {
             }
         }
         unsafe {
-            // This causes the `RwLock` and hook vector to be dropped. 
+            // This causes the `RwLock` and hook vector to be dropped.
             // plugin authors need to ensure that no threads are running when
             // their plugins are unloading - or one may try to access the lock
             // and hook vector after they've been destroyed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 
-//! This crate provides a Rust interface to the 
+//! This crate provides a Rust interface to the
 //! [Hexchat Plugin Interface](https://hexchat.readthedocs.io/en/latest/plugins.html)
-//! The primary object of the interface is 
+//! The primary object of the interface is
 //! [Hexchat](https://ttappr.github.io/hexchat_api/hexchat_api/struct.Hexchat.html),
-//! which exposes an interface with functions that mirror the C functions 
-//! listed on the Hexchat docs page linked above.  
+//! which exposes an interface with functions that mirror the C functions
+//! listed on the Hexchat docs page linked above.
 
 mod hook;
 mod callback_data;

--- a/src/list_item.rs
+++ b/src/list_item.rs
@@ -1,6 +1,6 @@
 
 //! A list item for the `ListIterator` and `ThreadSafeListIterator` items that
-//! can populate a vector generated using `ThreadSafeListIterator.to_vec()`, 
+//! can populate a vector generated using `ThreadSafeListIterator.to_vec()`,
 //! or using the same function of `ListIterator`. `ListItem`s can also be
 //! obtained using the `.get_item()` method of the list classes.
 
@@ -55,7 +55,7 @@ impl Index<&str> for ListItem {
 }
 
 impl From<ListIterator> for ListItem {
-    /// Consructs a list item from the given `ListIterator` instance and 
+    /// Consructs a list item from the given `ListIterator` instance and
     /// consumes it. The item is constructed from the fields retrieved from
     /// the iterator at its current position.
     ///
@@ -69,7 +69,7 @@ impl From<ListIterator> for ListItem {
 }
 
 impl From<&ListIterator> for ListItem {
-    /// Constructs a list item from the iterator reference at its current 
+    /// Constructs a list item from the iterator reference at its current
     /// position.
     ///
     fn from(list: &ListIterator) -> Self {

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -363,7 +363,9 @@ impl error::Error for ListError {}
 
 impl fmt::Display for ListError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        let mut s = format!("{:?}", self);
+        s.retain(|c| c != '"');
+        write!(f, "{}", s)
     }
 }
 

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -356,7 +356,7 @@ pub enum ListError {
     NotStarted(String),
     NotAvailable(String),
     ListIteratorDropped(String),
-    ThreadsafeOperationFailed(String),
+    ThreadSafeOperationFailed(String),
 }
 
 impl error::Error for ListError {}
@@ -372,7 +372,7 @@ impl fmt::Display for ListError {
             ListIteratorDropped(msg) => {
                 write!(f, "ListIteratorDropped(\"{}\")", msg)
             },
-            ThreadsafeOperationFailed(msg) => {
+            ThreadSafeOperationFailed(msg) => {
                 write!(f, "ThreadsafeOperationFailed(\"{}\")", msg)
             },
         }

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -356,6 +356,7 @@ pub enum ListError {
     NotStarted(String),
     NotAvailable(String),
     ListIteratorDropped(String),
+    ThreadsafeOperationFailed(String),
 }
 
 impl error::Error for ListError {}
@@ -370,6 +371,9 @@ impl fmt::Display for ListError {
             NotAvailable(msg) => { write!(f, "NotAvailable(\"{}\")", msg) },
             ListIteratorDropped(msg) => {
                 write!(f, "ListIteratorDropped(\"{}\")", msg)
+            },
+            ThreadsafeOperationFailed(msg) => {
+                write!(f, "ThreadsafeOperationFailed(\"{}\")", msg)
             },
         }
     }

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -363,19 +363,7 @@ impl error::Error for ListError {}
 
 impl fmt::Display for ListError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            UnknownList(msg)  => { write!(f, "UnknownList(\"{}\")", msg) },
-            UnknownField(msg) => { write!(f, "UnknownField(\"{}\")", msg) },
-            UnknownType(msg)  => { write!(f, "UnknownType(\"{:?}\")", msg) },
-            NotStarted(msg)   => { write!(f, "NotStarted(\"{}\")", msg) },
-            NotAvailable(msg) => { write!(f, "NotAvailable(\"{}\")", msg) },
-            ListIteratorDropped(msg) => {
-                write!(f, "ListIteratorDropped(\"{}\")", msg)
-            },
-            ThreadSafeOperationFailed(msg) => {
-                write!(f, "ThreadsafeOperationFailed(\"{}\")", msg)
-            },
-        }
+        write!(f, "{:?}", self)
     }
 }
 

--- a/src/list_iterator.rs
+++ b/src/list_iterator.rs
@@ -94,7 +94,7 @@ impl ListIterator {
             None
         }
     }
-    
+
     /// Eagerly constructs a vector of `ListItem`s. The iterator will be spent
     /// afterward.
     ///
@@ -102,7 +102,7 @@ impl ListIterator {
         self.map(ListItem::from).collect()
     }
 
-    /// Creates a `ListItem` from the field data at the current position in 
+    /// Creates a `ListItem` from the field data at the current position in
     /// the list.
     ///
     pub fn get_item(&self) -> ListItem {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -39,7 +39,7 @@ impl Plugin {
     pub fn new(file_name    : &str,
                plugin_name  : &str,
                description  : &str,
-               version      : &str) 
+               version      : &str)
         -> Plugin
     {
         unsafe {

--- a/src/thread_facilities.rs
+++ b/src/thread_facilities.rs
@@ -1,17 +1,17 @@
 #![cfg(feature = "threadsafe")]
 
-//! This module provides facilities for accessing Hexchat from routines  
-//! running on threads other than Hexchat's main thread. 
-//! 
+//! This module provides facilities for accessing Hexchat from routines
+//! running on threads other than Hexchat's main thread.
+//!
 //! Hexchat's plugin API isn't inherently thread-safe, however plugins
 //! can spawn separate threads and invoke Hexchat's API by placing routines
-//! to execute on Hexchat's main thread. 
-//! 
-//! `main_thread()` makes it easy to declare a function, or closure, that 
+//! to execute on Hexchat's main thread.
+//!
+//! `main_thread()` makes it easy to declare a function, or closure, that
 //! contains Hexchat API calls. Once executed, it uses the timer feature
 //! of Hexchat to delegate. The function or closure can return any sendable
 //! cloneable value, and `main_thread()` will pass that back to the calling
-//! thread via an `AsyncResult` object. This can either be ignored, and 
+//! thread via an `AsyncResult` object. This can either be ignored, and
 //! the thread can continue doing other work, or `AsyncResult.get()` can be
 //! invoked on the result object; this call will block until the main thread
 //! has finished executing the callback.
@@ -31,7 +31,7 @@ use UserData::*;
 const TASK_SPURT_SIZE: i32 = 5;
 const TASK_REST_MSECS: i64 = 2;
 
-// The type of the queue that closures will be added to and pulled from to run 
+// The type of the queue that closures will be added to and pulled from to run
 // on the main thread of Hexchat.
 type TaskQueue = LinkedList<Box<dyn Task>>;
 
@@ -43,20 +43,20 @@ static mut TASK_QUEUE: Option<Arc<Mutex<Option<TaskQueue>>>> = None;
 /// The main thread's ID is captured and used by `main_thread()` to determine
 /// whether it is being called from the main thread or not. If not, the
 /// callback can be invoked right away. Otherwise, it gets scheduled.
-/// 
+///
 pub(crate) static mut MAIN_THREAD_ID: Option<thread::ThreadId> = None;
 
 /// Base trait for items placed on the task queue.
-/// 
+///
 trait Task : Send {
     fn execute(&mut self, hexchat: &Hexchat);
     fn set_error(&mut self, error: &str);
 }
 
 /// A task that executes a closure on the main thread.
-/// 
-struct ConcreteTask<F, R> 
-where 
+///
+struct ConcreteTask<F, R>
+where
     F: FnMut(&Hexchat) -> R,
     R: Clone + Send,
 {
@@ -64,7 +64,7 @@ where
     result   : AsyncResult<R>,
 }
 
-impl<F, R> ConcreteTask<F, R> 
+impl<F, R> ConcreteTask<F, R>
 where
     F: FnMut(&Hexchat) -> R,
     R: Clone + Send,
@@ -77,26 +77,26 @@ where
     }
 }
 
-impl<F, R> Task for ConcreteTask<F, R> 
+impl<F, R> Task for ConcreteTask<F, R>
 where
     F: FnMut(&Hexchat) -> R,
     R: Clone + Send,
 {
     /// Executes the closure and sets the result.
-    /// 
+    ///
     fn execute(&mut self, hexchat: &Hexchat) {
         self.result.set((self.callback)(hexchat));
     }
     /// When the task queue is being shut down, this will be called to set the
     /// result to an error.
-    /// 
+    ///
     fn set_error(&mut self, error: &str) {
         self.result.set_error(error);
     }
 }
 
-unsafe impl<F, R> Send for ConcreteTask<F, R> 
-where 
+unsafe impl<F, R> Send for ConcreteTask<F, R>
+where
     F: FnMut(&Hexchat) -> R,
     R: Clone + Send,
 {}
@@ -104,7 +104,7 @@ where
 /// An error type that can be used to indicate that a task failed. Currently,
 /// this is only used when the task queue is being shut down. This happens
 /// when Hexchat is closing or the addon is being unloaded.
-/// 
+///
 #[derive(Debug, Clone)]
 pub struct TaskError(pub(crate) String);
 
@@ -121,7 +121,7 @@ impl Display for TaskError {
 /// return data needs to be transferred or not, this object can be used to wait
 /// on the completion of a callback, thus providing synchronization between
 /// threads.
-/// 
+///
 #[allow(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct AsyncResult<T: Clone + Send> {
@@ -133,7 +133,7 @@ unsafe impl<T: Clone + Send> Sync for AsyncResult<T> {}
 
 impl<T: Clone + Send> AsyncResult<T> {
     /// Constructor. Initializes the return data to None.
-    /// 
+    ///
     pub (crate)
     fn new() -> Self {
         AsyncResult {
@@ -142,14 +142,14 @@ impl<T: Clone + Send> AsyncResult<T> {
     }
     /// Indicates whether the callback executing on another thread is done or
     /// not. This can be used to poll for the result.
-    /// 
+    ///
     pub fn is_done(&self) -> bool {
         let (mtx, _) = &*self.data;
         mtx.lock().unwrap().1
     }
     /// Blocking call to retrieve the return data from a callback on another
     /// thread.
-    /// 
+    ///
     pub fn get(&self) -> Result<T, TaskError> {
         let (mtx, cvar) = &*self.data;
         let mut guard   = mtx.lock().unwrap();
@@ -160,7 +160,7 @@ impl<T: Clone + Send> AsyncResult<T> {
     }
     /// Sets the return data for the async result. This will unblock the
     /// receiver waiting on the result from `get()`.
-    /// 
+    ///
     pub (crate)
     fn set(&self, result: T) {
         let (mtx, cvar) = &*self.data;
@@ -179,12 +179,12 @@ impl<T: Clone + Send> AsyncResult<T> {
 /// Executes a closure from the Hexchat main thread. This function returns
 /// immediately with an AsyncResult object that can be used to retrieve the
 /// result of the operation that will run on the main thread.
-/// 
+///
 /// # Arguments
 /// * `callback` - The callback to execute on the main thread.
-/// 
+///
 pub fn main_thread<F, R>(mut callback: F) -> AsyncResult<R>
-where 
+where
     F: FnMut(&Hexchat) -> R + Sync + Send,
     F: 'static + Send,
     R: 'static + Clone + Send,
@@ -201,7 +201,7 @@ where
             if let Some(queue) = arc.lock().unwrap().as_mut() {
                 let task = Box::new(ConcreteTask::new(callback, cln));
                 queue.push_back(task);
-            } 
+            }
             else {
                 res.set_error("Task queue has been shut down.");
             }
@@ -215,38 +215,38 @@ where
 /// This initializes the fundamental thread-safe features of this library.
 /// A mutex guarded task queue is created, and a timer function is registered
 /// that handles the queue at intervals. If a thread requires fast response,
-/// the handler will field its requests one after another for up to 
+/// the handler will field its requests one after another for up to
 /// `TASK_SPURT_SIZE` times without rest.
 ///
 pub (crate)
 fn main_thread_init() {
     unsafe { MAIN_THREAD_ID = Some(thread::current().id()) }
     if unsafe { TASK_QUEUE.is_none() } {
-        unsafe { 
-            TASK_QUEUE = Some(Arc::new(Mutex::new(Some(LinkedList::new())))); 
+        unsafe {
+            TASK_QUEUE = Some(Arc::new(Mutex::new(Some(LinkedList::new()))));
         }
         let hex = unsafe { &*PHEXCHAT };
-        
+
         hex.hook_timer(
             TASK_REST_MSECS,
             move |_hc, _ud| {
                 if let Some(arc) = unsafe { TASK_QUEUE.as_ref() } {
                     if arc.lock().unwrap().is_some() {
                         let mut count = 1;
-                        
-                        while let Some(mut task) 
+
+                        while let Some(mut task)
                             = arc.lock().unwrap().as_mut()
                                 .and_then(|q| q.pop_front()) {
                             task.execute(hex);
                             count += 1;
-                            if count > TASK_SPURT_SIZE { 
-                                break  
+                            if count > TASK_SPURT_SIZE {
+                                break
                             }
                         }
                         1 // Keep going.
                     } else {
                         0 // Task queue is gone, remove timer callback.
-                        }
+                    }
                 } else {
                     0 // Task queue is gone, remove timer callback.
                 }
@@ -274,21 +274,21 @@ fn main_thread_deinit() {
 }
 
 /// Stops and removes the main thread task queue handler. Otherwise it will
-/// keep checking the queue while doing nothing useful - which isn't 
+/// keep checking the queue while doing nothing useful - which isn't
 /// necessarily bad. Performance is unaffected either way.
 ///
-/// Support for `main_thread()` is on by default. After this function is 
+/// Support for `main_thread()` is on by default. After this function is
 /// invoked, `main_thread()` should not be used and threads in general risk
 /// crashing the software if they try to access Hexchat directly without
-/// the `main_thread()`. `ThreadSafeContext` and `ThreadSafeListIterator` 
-/// should also not be used after this function is called, since they rely on 
+/// the `main_thread()`. `ThreadSafeContext` and `ThreadSafeListIterator`
+/// should also not be used after this function is called, since they rely on
 /// `main_thread()` internally.
-/// 
+///
 /// # Safety
 /// While this will disable the handling of the main thread task queue, it
 /// doesn't prevent the plugin author from spawning threads and attempting to
-/// use the features of the threadsafe objects this crate provides. If the 
-/// plugin author intends to use `ThreadSafeContext`, `ThreadSafeListIterator`, 
+/// use the features of the threadsafe objects this crate provides. If the
+/// plugin author intends to use `ThreadSafeContext`, `ThreadSafeListIterator`,
 /// or invoke `main_thread()` directly, then this function should not be called.
 ///
 #[deprecated(

--- a/src/thread_facilities.rs
+++ b/src/thread_facilities.rs
@@ -112,7 +112,7 @@ impl Error for TaskError {}
 
 impl Display for TaskError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "TaskError(\"{}\")", self.0)
+        write!(f, "TaskError({})", self.0)
     }
 }
 

--- a/src/thread_facilities.rs
+++ b/src/thread_facilities.rs
@@ -106,13 +106,13 @@ where
 /// when Hexchat is closing or the addon is being unloaded.
 /// 
 #[derive(Debug, Clone)]
-pub struct TaskError(String);
+pub struct TaskError(pub(crate) String);
 
 impl Error for TaskError {}
 
 impl Display for TaskError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "TaskError: {}", self.0)
+        write!(f, "TaskError(\"{}\")", self.0)
     }
 }
 

--- a/src/threadsafe_hexchat.rs
+++ b/src/threadsafe_hexchat.rs
@@ -24,11 +24,11 @@ unsafe impl Sync for ThreadSafeHexchat {}
 
 impl ThreadSafeHexchat {
     /// Constructs a `ThreadSafeHexchat` object that wraps `Hexchat`.
-    pub (crate) 
+    pub (crate)
     fn new(_hc: &'static Hexchat) -> Self {
         ThreadSafeHexchat
     }
-    
+
     /// Prints the string passed to it to the active Hexchat window.
     /// # Arguments
     /// * `text` - The text to print.
@@ -41,7 +41,7 @@ impl ThreadSafeHexchat {
             |err| Err(CommandFailed(err.to_string())),
             Ok)
     }
-    
+
     /// Invokes the Hexchat command specified by `command`.
     /// # Arguments
     /// * `command` - The Hexchat command to invoke.
@@ -54,9 +54,9 @@ impl ThreadSafeHexchat {
             |err| Err(CommandFailed(err.to_string())),
             Ok)
     }
-    
+
     /// Returns a `ThreadSafeContext` object bound to the requested channel.
-    /// The object provides methods like `print()` that will execute the 
+    /// The object provides methods like `print()` that will execute the
     /// Hexchat print command in that tab/window related to the context.
     /// The `Context::find()` can also be invoked to find a context.
     /// # Arguments
@@ -64,12 +64,12 @@ impl ThreadSafeHexchat {
     /// * `channel`  - The channel name for the context (e.g. "##rust").
     /// # Returns
     /// * the thread-safe context was found, i.e. if the user is joined to the
-    ///   channel specified currently, a `Some(<Context>)` is returned with the
-    ///   context object; `None` otherwise.
+    ///   channel specified currently, the context or a `ContextError` if the
+    ///   context wasn't found, or another problem occurred..
     ///
-    pub fn find_context(&self, 
-                        network : &str, 
-                        channel : &str) 
+    pub fn find_context(&self,
+                        network : &str,
+                        channel : &str)
         -> Result<ThreadSafeContext, ContextError>
     {
         use ContextError::*;
@@ -80,7 +80,7 @@ impl ThreadSafeHexchat {
         .map_or_else(
             |err| Err(ThreadSafeOperationFailed(err.to_string())),
             |res| res.map_or_else(
-                || Err(AcquisitionFailed(network.into(), channel.into())), 
+                || Err(AcquisitionFailed(network.into(), channel.into())),
                 Ok))
     }
 
@@ -93,7 +93,7 @@ impl ThreadSafeHexchat {
     /// the Hexchat API within the context the object is bound to. Also,
     /// `Context::get()` will return a context object for the current context.
     /// # Returns
-    /// * The `ThreadSafeContext` for the currently active context. This usually 
+    /// * The `ThreadSafeContext` for the currently active context. This usually
     ///   means the channel window the user has visible in the GUI.
     ///
     pub fn get_context(&self) -> Result<ThreadSafeContext, ContextError> {
@@ -103,10 +103,10 @@ impl ThreadSafeHexchat {
         }).get().map_or_else(
             |err| Err(ThreadSafeOperationFailed(err.to_string())),
             |res| res.map_or_else(
-                || Err(AcquisitionFailed("?".into(), "?".into())), 
+                || Err(AcquisitionFailed("?".into(), "?".into())),
                 Ok))
     }
-        
+
     /// Retrieves the info data with the given `id`. It returns None on failure
     /// and `Some(String)` on success. All information is returned as String
     /// data - even the "win_ptr"/"gtkwin_ptr" values, which can be parsed
@@ -117,28 +117,28 @@ impl ThreadSafeHexchat {
     ///          Plugin Interface page under `hexchat_get_info()`. These include
     ///          "channel", "network", "topic", etc.
     /// # Returns
-    /// * `Some(<String>)` is returned with the string value of the info
-    ///   requested. `None` is returned if there is no info with the requested
-    ///   `id`.
+    /// * The string is returned for the info requested. `HexchatError`` is 
+    ///   returned if there is no info with the requested `id` or another 
+    ///   problem occurred.
     ///
     pub fn get_info(&self, id: &str) -> Result<String, HexchatError> {
         use HexchatError::*;
         let id = id.to_string();
         main_thread(move |hc| {
             hc.get_info(&id)
-        }).get()            
+        }).get()
         .map_or_else(
             |err| Err(CommandFailed(err.to_string())),
             |res| res.map_or_else(
-                || Err(CommandFailed("No info found".into())), 
+                || Err(CommandFailed("No info found".into())),
                 Ok))
     }
-    
+
     /// Creates an iterator for the requested Hexchat list. This is modeled
     /// after how Hexchat implements the listing feature: rather than load
     /// all the list items up front, an internal list pointer is advanced
     /// to the current item, and the fields of which are accessible through
-    /// the iterator's `.get_field()` function. 
+    /// the iterator's `.get_field()` function.
     /// See the Hexchat Plugin Interface web page for more information on the
     /// related lists.
     /// # Arguments

--- a/src/threadsafe_list_iterator.rs
+++ b/src/threadsafe_list_iterator.rs
@@ -54,51 +54,70 @@ impl ThreadSafeListIterator {
     /// # Returns
     /// * A thread-safe object representing one of Hexchat's internal lists.
     ///
-    pub fn new(name: &str) -> Option<Self> {
-        let name = name.to_string();
+    pub fn new(name: &str) -> Result<Self, ListError> {
+        use ListError::*;
+        let cname = name.to_string();
         main_thread(move |_| {
-            ListIterator::new(&name).map(|list| 
+            ListIterator::new(&cname).map(|list| 
                 ThreadSafeListIterator {
                     list_iter: 
                         Arc::new(RwLock::new(Some(SendWrapper::new(list))))
                 })}
-        ).get().unwrap()
+        ).get()
+        .map_or_else(
+            |err| Err(ThreadSafeOperationFailed(err.to_string())),
+            |res| res.map_or_else(|| Err(UnknownList(name.into())), Ok))
     }
     
     /// Returns a vector of the names of the fields supported by the list
     /// the list iterator represents.
     ///
-    pub fn get_field_names(&self) -> Vec<String> {
+    pub fn get_field_names(&self) -> Result<Vec<String>, ListError> {
+        use ListError::*;
         let me = self.clone();
         main_thread(move |_| {
-            me.list_iter.read().unwrap().as_ref()
-                        .expect("ListIterator dropped from threadsafe context.")
-                        .get_field_names().to_vec()
-        }).get().unwrap()
+            Ok(me.list_iter.read().unwrap().as_ref()
+                 .ok_or_else(
+                    || ListIteratorDropped("ListIterator dropped from \
+                                            threadsafe context.".into()))?
+                 .get_field_names().to_vec())
+        }).get()
+        .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
+                     |res| res)
     }
     
     /// Constructs a vector of list items on the main thread all at once. The
     /// iterator will be spent after the operation.
     ///
-    pub fn to_vec(&self) -> Vec<ListItem> {
+    pub fn to_vec(&self) -> Result<Vec<ListItem>, ListError> {
+        use ListError::*;
         let me = self.clone();
         main_thread(move |_| {
-            me.list_iter.read().unwrap().as_ref()
-                        .expect("ListIterator dropped from threadsafe context.")
-                        .to_vec()
-        }).get().unwrap()
+            Ok(me.list_iter.read().unwrap().as_ref()
+                 .ok_or_else(
+                    ||ListIteratorDropped("ListIterator dropped from \
+                                           threadsafe context.".into()))?
+                 .to_vec())
+        }).get()
+        .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
+                     |res| res)        
     }
     
     /// Creates a `ListItem` from the field data at the current position in the
     /// list.
     ///
-    pub fn get_item(&self) -> ListItem {
+    pub fn get_item(&self) -> Result<ListItem, ListError> {
+        use ListError::*;
         let me = self.clone();
         main_thread(move |_| {
-            me.list_iter.read().unwrap().as_ref()
-                        .expect("ListIterator dropped from threadsafe context.")
-                        .get_item()
-        }).get().unwrap()
+            Ok(me.list_iter.read().unwrap().as_ref()
+                 .ok_or_else(
+                    ||ListIteratorDropped("ListIterator dropped from \
+                                           threadsafe context.".into()))?
+                 .get_item())
+        }).get()
+        .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
+                     |res| res)        
     }
     
     /// Returns the value for the field of the requested name.
@@ -116,6 +135,7 @@ impl ThreadSafeListIterator {
                      name: &str
                     ) -> Result<ThreadSafeFieldValue, ListError> 
     {
+        use ListError::*;
         use FieldValue as FV;
         use ThreadSafeFieldValue as TSFV;
         
@@ -154,7 +174,10 @@ impl ThreadSafeListIterator {
                     "ListIterator dropped from threadsafe context."
                     .to_string()))
             }
-        }).get().unwrap()
+        }).get()
+        .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
+                     |res| res)        
+
     }
 }
 

--- a/src/threadsafe_list_iterator.rs
+++ b/src/threadsafe_list_iterator.rs
@@ -191,7 +191,7 @@ impl Iterator for ThreadSafeListIterator {
             } else {
                 None
             }
-        }).get().unwrap()
+        }).get().unwrap_or(None)
     }
 }
 
@@ -202,7 +202,7 @@ impl Iterator for &ThreadSafeListIterator {
         let has_more = main_thread(move |_| {
             me.list_iter.write().unwrap().as_mut()
                         .map_or(false, |it| it.next().is_some())
-        }).get().unwrap();
+        }).get().unwrap_or(false);
         if has_more {
             Some(self)
         } else {

--- a/src/threadsafe_list_iterator.rs
+++ b/src/threadsafe_list_iterator.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "threadsafe")]
 
-//! This module provides a thread-safe wrapper class for the Hexchat 
+//! This module provides a thread-safe wrapper class for the Hexchat
 //! `ListIterator`. The methods it provides can be invoked from threads other
 //! than the Hexchat main thread safely.
 
@@ -20,12 +20,12 @@ use crate::threadsafe_context::*;
 /// additional code necessary to make that happen in the client code.
 ///
 /// Objects of this struct can iterate over Hexchat's lists from other threads.
-/// Because each operation is delegated to the main thread from the current 
-/// thread, they are not going to be as fast as the methods of `ListIterator` 
+/// Because each operation is delegated to the main thread from the current
+/// thread, they are not going to be as fast as the methods of `ListIterator`
 /// used exclusively in the main thread without switching to other threads.
 /// The plus to objects of this struct iterating and printing long lists is they
 /// won't halt or lag the Hexchat UI. The list can print item by item, while
-/// while Hexchat is able to handle its traffic, printing chat messages, and 
+/// while Hexchat is able to handle its traffic, printing chat messages, and
 /// other tasks.
 ///
 #[derive(Clone)]
@@ -41,13 +41,13 @@ impl ThreadSafeListIterator {
     /// # Arguments
     /// * `list_iter` - The list iterator to wrap.
     ///
-    pub (crate) 
+    pub (crate)
     fn create(list_iter: ListIterator) -> Self {
-        Self { 
-            list_iter: Arc::new(RwLock::new(Some(SendWrapper::new(list_iter)))) 
+        Self {
+            list_iter: Arc::new(RwLock::new(Some(SendWrapper::new(list_iter))))
         }
     }
-    
+
     /// Produces the list associated with `name`.
     /// # Arguments
     /// * `name` - The name of the list to get.
@@ -58,9 +58,9 @@ impl ThreadSafeListIterator {
         use ListError::*;
         let cname = name.to_string();
         main_thread(move |_| {
-            ListIterator::new(&cname).map(|list| 
+            ListIterator::new(&cname).map(|list|
                 ThreadSafeListIterator {
-                    list_iter: 
+                    list_iter:
                         Arc::new(RwLock::new(Some(SendWrapper::new(list))))
                 })}
         ).get()
@@ -68,7 +68,7 @@ impl ThreadSafeListIterator {
             |err| Err(ThreadSafeOperationFailed(err.to_string())),
             |res| res.map_or_else(|| Err(UnknownList(name.into())), Ok))
     }
-    
+
     /// Returns a vector of the names of the fields supported by the list
     /// the list iterator represents.
     ///
@@ -85,7 +85,7 @@ impl ThreadSafeListIterator {
         .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
                      |res| res)
     }
-    
+
     /// Constructs a vector of list items on the main thread all at once. The
     /// iterator will be spent after the operation.
     ///
@@ -100,9 +100,9 @@ impl ThreadSafeListIterator {
                  .to_vec())
         }).get()
         .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
-                     |res| res)        
+                     |res| res)
     }
-    
+
     /// Creates a `ListItem` from the field data at the current position in the
     /// list.
     ///
@@ -117,9 +117,9 @@ impl ThreadSafeListIterator {
                  .get_item())
         }).get()
         .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
-                     |res| res)        
+                     |res| res)
     }
-    
+
     /// Returns the value for the field of the requested name.
     ///
     /// # Arguments
@@ -131,14 +131,14 @@ impl ThreadSafeListIterator {
     ///   error types. The values are returned as `FieldValue` tuples that hold
     ///   the requested data.
     ///
-    pub fn get_field(&self, 
+    pub fn get_field(&self,
                      name: &str
-                    ) -> Result<ThreadSafeFieldValue, ListError> 
+                    ) -> Result<ThreadSafeFieldValue, ListError>
     {
         use ListError::*;
         use FieldValue as FV;
         use ThreadSafeFieldValue as TSFV;
-        
+
         let name = name.to_string();
         let me = self.clone();
         main_thread(move |_| {
@@ -176,7 +176,7 @@ impl ThreadSafeListIterator {
             }
         }).get()
         .map_or_else(|err| Err(ThreadSafeOperationFailed(err.to_string())),
-                     |res| res)        
+                     |res| res)
 
     }
 }
@@ -223,7 +223,7 @@ impl Drop for ThreadSafeListIterator {
     }
 }
 
-/// Thread-safe versions of the `FieldValue` variants provided by 
+/// Thread-safe versions of the `FieldValue` variants provided by
 /// `ListIterator`.
 /// # Variants
 /// * StringVal    - A string has been returned. The enum item holds its value.

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -83,7 +83,7 @@ impl UserData {
     ///         is the return type that gets wrapped in an `Option` and returned
     ///         by `apply()`.
     /// # Returns
-    /// * Returns the return value of function `f` if the downcast is 
+    /// * Returns the return value of function `f` if the downcast is
     ///   successful.
     ///
     pub fn apply<D:'static, F, R>(&self, f: F) -> R
@@ -104,7 +104,7 @@ impl UserData {
             NoData => { panic!("Can't downcast `NoData`.") },
         }
     }
-    
+
     /// Same as the `apply()` function except allows mutable access to the
     /// user data contents.
     ///
@@ -130,7 +130,7 @@ impl UserData {
 
 impl Clone for UserData {
     /// The clone operation for `UserData` allows each variant to be cloned,
-    /// except for `BoxedData`. The reason `BoxedData` is prohibited is to 
+    /// except for `BoxedData`. The reason `BoxedData` is prohibited is to
     /// deter sharing a box between callbacks, as that's not what
     /// a box is meant to be used for. One of the shared variants is more
     /// appropriate to share access to user data.
@@ -140,7 +140,7 @@ impl Clone for UserData {
             SharedData(d) => { SharedData(d.clone()) },
             SyncData(d)   => { SyncData(d.clone()) },
             NoData        => { NoData },
-            BoxedData(_)  => { 
+            BoxedData(_)  => {
                 panic!("Can't clone `BoxedData`. If user data needs to be \
                         shared, The `SharedData` or `SyncData` variants of \
                        `UserData` should be used.")
@@ -151,7 +151,7 @@ impl Clone for UserData {
 
 impl Default for UserData {
     /// Implemented to support the `take()` operation in `CallbackData` so the
-    /// user data can be retrieved with ownership when a callback is 
+    /// user data can be retrieved with ownership when a callback is
     /// deregistered. That take operation replaces the user data the callback
     /// owns with the default value (`NoData`).
     ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,10 +15,10 @@ fn str2cstring(s: &str) -> CString {
 }
 
 /// Reduces the syntax required to output formatted text to the current
-/// hexchat window. Internally it invokes 
+/// hexchat window. Internally it invokes
 /// `hexchat.print(&format!("<format-string>", arg1, arg2, ...)`.
-/// Using the macro, this becomes 
-/// `hc_print!("<format_string>", arg1, arg2, ...)`. To print from another 
+/// Using the macro, this becomes
+/// `hc_print!("<format_string>", arg1, arg2, ...)`. To print from another
 /// thread `hc_print_th!()` can be used.
 /// ```
 /// use hexchat_api::hc_print;
@@ -31,7 +31,7 @@ fn str2cstring(s: &str) -> CString {
 /// * `ctx=(network, channel)` - Sets the context to print in.
 /// * `fmt`     - The format string.
 /// * `argv`    - The varibale length formatted arguments.
-/// 
+///
 #[macro_export]
 macro_rules! hc_print {
     ( ctx = ($network:expr, $channel:expr), $( $arg:tt )* ) => {
@@ -45,7 +45,7 @@ macro_rules! hc_print {
 
 /// Used by `hc_print!()` to print to a specific context. This function is
 /// not intended to be used directly.
-/// 
+///
 #[doc(hidden)]
 pub fn print_with_ctx_inner(network: &str, channel: &str, msg: &str) {
     let hc = unsafe { &*PHEXCHAT };
@@ -64,7 +64,7 @@ pub fn print_with_ctx_inner(network: &str, channel: &str, msg: &str) {
 
 /// Used by `hc_print!()` to print to the active Hexchat window. This function
 /// is not intended to be used directly.
-/// 
+///
 #[doc(hidden)]
 pub fn print_inner(msg: &str) {
     let hc = unsafe { &*PHEXCHAT };
@@ -85,7 +85,7 @@ pub fn print_inner(msg: &str) {
 /// * `ctx=(network, channel)` - Sets the context to print in.
 /// * `fmt`     - The format string.
 /// * `argv`    - The varibale length formatted arguments.
-/// 
+///
 #[macro_export]
 macro_rules! hc_print_th {
     (  ctx = ($network:expr, $channel:expr), $( $arg:tt )* ) => {
@@ -105,7 +105,7 @@ macro_rules! hc_print_th {
 
 /// Executes a command in the active Hexchat window. Provided for convenience
 /// to support formatted string commands.
-/// 
+///
 #[macro_export]
 macro_rules! hc_command {
     ( $( $arg:tt )* ) => {
@@ -115,7 +115,7 @@ macro_rules! hc_command {
 
 /// Executes a command on the main thread. This is useful for executing
 /// commands from spawned threads.
-/// 
+///
 #[macro_export]
 macro_rules! hc_command_th {
     ( $( $arg:tt )* ) => {
@@ -126,7 +126,7 @@ macro_rules! hc_command_th {
 
 /// Executes a command in the active Hexchat window. This function is not
 /// intended to be used directly.
-/// 
+///
 #[doc(hidden)]
 pub fn command_inner(cmd: &str) {
     let hc = unsafe { &*PHEXCHAT };


### PR DESCRIPTION
Removed panics from threadsafe object calls. They now return errors in their Result's. Methods that had nested Object's within Results now return the result of it succeeds, and if not, the Result's error will indicate this.